### PR TITLE
Remove reference to LaTeX in naming

### DIFF
--- a/quiz_generator/question.py
+++ b/quiz_generator/question.py
@@ -42,15 +42,15 @@ class Question:
         if answer_generation_function:
             self.answers = answer_generation_function(inputs)
 
-    def question_to_latex(self):
-        """Write out a representation of the question to LaTeX"""
+    def render_question(self):
+        """Render the question template with the question inputs"""
         if self.question_inputs:
             return self.question_template.render(self.question_inputs)
         else:
             return self.question_template.render()
 
-    def answer_to_latex(self):
-        """Write out a representation of the answer to LaTeX"""
+    def render_answer(self):
+        """Render the answer template with the answers"""
         if self.answer_generation_function:
             return self.answer_template.render(self.answers)
         else:

--- a/quiz_generator/quiz.py
+++ b/quiz_generator/quiz.py
@@ -57,8 +57,12 @@ class Quiz:
         })
         return rendered_output
 
-    def quiz_to_latex(self):
-        """Output the quiz in a LaTeX format"""
+    def render(self):
+        """
+        Render the quiz using the provided template
+        :rtype: str
+        :returns: A string with the rendered quiz
+        """
         rendered_output = self.quiz_questions_template.render({
             "quiz_name": self.quiz_name,
             "quiz_version": self.quiz_version,

--- a/quiz_generator/tests/test_question.py
+++ b/quiz_generator/tests/test_question.py
@@ -8,8 +8,8 @@ from quiz_generator.question import Question
 def test_question_with_no_substitution():
     """Test that a question with no function to substitute values works as expected"""
     simple_question = Question("1+1 = ?", "2")
-    assert simple_question.question_to_latex() == "1+1 = ?"
-    assert simple_question.answer_to_latex() == "2"
+    assert simple_question.render_question() == "1+1 = ?"
+    assert simple_question.render_answer() == "2"
 
 def test_question_with_template():
     """Test that a question with a templated input works as expected"""
@@ -22,8 +22,8 @@ def test_question_with_template():
         answer_template=a_template,
         inputs=input_name
     )
-    assert question_with_template.question_to_latex() == "Hi I'm bob!"
-    assert question_with_template.answer_to_latex() == "This wasn't really a question, so there's no answer"
+    assert question_with_template.render_question() == "Hi I'm bob!"
+    assert question_with_template.render_answer() == "This wasn't really a question, so there's no answer"
 
 def test_question_with_function():
     """Test a question is generated with a provided function"""
@@ -47,8 +47,8 @@ def test_question_with_function():
         inputs=inputs,
         answer_generation_function=answer_function
     )
-    assert question_with_function.question_to_latex() == "What is 1+2 ?"
-    assert question_with_function.answer_to_latex() == "3"
+    assert question_with_function.render_question() == "What is 1+2 ?"
+    assert question_with_function.render_answer() == "3"
 
 def test_bad_parameters_to_question():
     """Test that bad parameters passed to Question raise exceptions"""

--- a/quiz_generator/tests/test_quiz.py
+++ b/quiz_generator/tests/test_quiz.py
@@ -34,7 +34,7 @@ def test_quiz_creation():
         questions=[question1, question2],
         quiz_name=name
     )
-    rendered_quiz = test_quiz.quiz_to_latex()
+    rendered_quiz = test_quiz.render()
     assert name in rendered_quiz
     assert question_1_text in rendered_quiz
     assert question_2_text in rendered_quiz

--- a/quiz_generator/tests/test_ranged_question.py
+++ b/quiz_generator/tests/test_ranged_question.py
@@ -47,8 +47,8 @@ def test_question_generation():
     )
 
     generated_question = question_with_function_over_range.create_specific_question()
-    assert generated_question.question_to_latex() in ("What is 1^2 ?", "What is 2^2 ?")
-    assert generated_question.answer_to_latex() in ("1", "4")
+    assert generated_question.render_question() in ("What is 1^2 ?", "What is 2^2 ?")
+    assert generated_question.render_answer() in ("1", "4")
 
 def test_extract_input_combination():
     """Test helper function that extracts a single value from a dictionary containing choices"""


### PR DESCRIPTION
There's really nothing in these methods that is LaTeX specific, they just render a template (which could contain LaTeX but does not have to) so the method name is misleading.